### PR TITLE
Update lspconfig remappings

### DIFF
--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -27,9 +27,6 @@ function M.init()
       end,
     },
     mapping = {
-      ["<C-j>"] = cmp.mapping.scroll_docs(-4),
-      ["<C-k>"] = cmp.mapping.scroll_docs(4),
-      ["<C-e>"] = cmp.mapping.close(),
       ["<CR>"] = cmp.mapping.confirm {
         behavior = cmp.ConfirmBehavior.Replace,
         select = true,

--- a/lua/plugins/dap.lua
+++ b/lua/plugins/dap.lua
@@ -136,10 +136,10 @@ extend_repl = function()
 end
 
 set_user_commands = function()
-  -- toggle repl vertical split with <leader> + d
+  -- toggle repl vertical split with <leader> + r
   vim.api.nvim_set_keymap(
     "n",
-    "<leader>d",
+    "<leader>r",
     "<CMD>lua require('plugins.dap').toggle_repl()<CR>",
     { noremap = true, silent = true }
   )

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -114,7 +114,15 @@ function plugins.setup()
     use {
       "nvim-telescope/telescope.nvim",
       opt = true,
-      keys = { "<leader>n", "<C-x>", "<leader>g", "<C-g>", "<C-n>" },
+      keys = {
+        "<leader>n",
+        "<C-x>",
+        "<leader>g",
+        "<C-g>",
+        "<C-n>",
+        "<leader>d",
+        "<leader>q",
+      },
       config = function()
         require("plugins.telescope").init()
         --NOTE: this requires plenary.nvim

--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -11,7 +11,7 @@ local lspconfig = {}
 ---Definition of word under the cursor with "shift + K"
 ---If there are diagnostics on line the "shit + K " will display
 ---diagnostics instead.
----"Ctrl + d" will show only definition.
+---"Ctrl + k" will show only definition.
 function lspconfig.init()
   vim.api.nvim_set_keymap(
     "n",
@@ -22,7 +22,7 @@ function lspconfig.init()
       noremap = true,
     }
   )
-  vim.api.nvim_set_keymap("n", "<C-d>", "<cmd>lua vim.lsp.buf.hover()<CR>", {
+  vim.api.nvim_set_keymap("n", "<C-k>", "<cmd>lua vim.lsp.buf.hover()<CR>", {
     silent = true,
     noremap = true,
   })

--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -7,11 +7,22 @@
 
 local lspconfig = {}
 
----Definition of word under the cursor with "shift + K"
 ---Jump to definition with "gd"
----Open current line's diagnostic with <leader> + d
+---Definition of word under the cursor with "shift + K"
+---If there are diagnostics on line the "shit + K " will display
+---diagnostics instead.
+---"Ctrl + d" will show only definition.
 function lspconfig.init()
-  vim.api.nvim_set_keymap("n", "K", "<cmd>lua vim.lsp.buf.hover()<CR>", {
+  vim.api.nvim_set_keymap(
+    "n",
+    "K",
+    "<cmd>lua require('plugins.lspconfig').show_definition()<CR>",
+    {
+      silent = true,
+      noremap = true,
+    }
+  )
+  vim.api.nvim_set_keymap("n", "<C-d>", "<cmd>lua vim.lsp.buf.hover()<CR>", {
     silent = true,
     noremap = true,
   })
@@ -19,15 +30,16 @@ function lspconfig.init()
     silent = true,
     noremap = true,
   })
-  vim.api.nvim_set_keymap(
-    "n",
-    "<leader>d",
-    "<cmd>lua vim.diagnostic.open_float()<CR>",
-    {
-      silent = true,
-      noremap = true,
-    }
-  )
+end
+
+---Show definition of symbol under cursor, unless
+---there are any diagnostics on the current line.
+---Then display those diagnostics instead.
+function lspconfig.show_definition()
+  if vim.diagnostic.open_float() then
+    return
+  end
+  vim.lsp.buf.hover()
 end
 
 local distinct_setups = {}

--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -12,6 +12,7 @@ local lspconfig = {}
 ---If there are diagnostics on line the "shit + K " will display
 ---diagnostics instead.
 ---"Ctrl + k" will show only definition.
+---"Ctrl + d" will show only diagnostics.
 function lspconfig.init()
   vim.api.nvim_set_keymap(
     "n",
@@ -26,6 +27,15 @@ function lspconfig.init()
     silent = true,
     noremap = true,
   })
+  vim.api.nvim_set_keymap(
+    "n",
+    "<C-d>",
+    "<cmd>lua vim.diagnostic.open_float()<CR>",
+    {
+      silent = true,
+      noremap = true,
+    }
+  )
   vim.api.nvim_set_keymap("n", "gd", "<cmd>lua vim.lsp.buf.definition()<CR>", {
     silent = true,
     noremap = true,

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -85,6 +85,15 @@ function M.remappings()
   )
   vim.api.nvim_set_keymap(
     "n",
+    "<leader>d",
+    "<cmd>lua require('telescope.builtin').diagnostics()<CR>",
+    {
+      silent = true,
+      noremap = true,
+    }
+  )
+  vim.api.nvim_set_keymap(
+    "n",
     "<C-x>",
     "<cmd>lua require('telescope.builtin').grep_string()<CR>",
     {


### PR DESCRIPTION
- Update telescope diagnostics with `<leader>d`
   - Dap repl is now toggled with `<leader>r` instead of `<leader>d`
   
- `<Shift-k` now shows diagnostics instead of definition if there are any.
  - When there are none it still opens the definition of the symbol under the cursor.
  - `<Ctrl-k>` now opens only the definition.
  - `<Ctrl-d>` show only the diagnostics (if any)