### PR TITLE
GitHub Copilot

### DIFF
--- a/ftplugin/go.lua
+++ b/ftplugin/go.lua
@@ -87,3 +87,8 @@ require("plugins.actions").distinct_setup("go", {
     end,
   },
 })
+
+----------------------------------------------------------------------- COPILOT
+-- NOTE: enable copilot for go
+
+require("plugins.copilot").enable()

--- a/ftplugin/lua.lua
+++ b/ftplugin/lua.lua
@@ -69,3 +69,8 @@ require("plugins.formatter").distinct_setup("lua", {
     },
   },
 })
+
+----------------------------------------------------------------------- COPILOT
+-- NOTE: enable copilot for lua
+
+require("plugins.copilot").enable()

--- a/ftplugin/ocaml.lua
+++ b/ftplugin/ocaml.lua
@@ -78,3 +78,9 @@ require("plugins.actions").distinct_setup("ocaml", {
     end,
   },
 })
+
+
+----------------------------------------------------------------------- COPILOT
+-- NOTE: enable copilot for OCaml
+
+require("plugins.copilot").enable()

--- a/ftplugin/python.lua
+++ b/ftplugin/python.lua
@@ -101,3 +101,8 @@ require("plugins.actions").distinct_setup("python", {
     end,
   },
 })
+
+----------------------------------------------------------------------- COPILOT
+-- NOTE: enable github copilot if it is not already enabled
+
+require("plugins.copilot").enable()

--- a/ftplugin/ruby.lua
+++ b/ftplugin/ruby.lua
@@ -111,3 +111,8 @@ require("plugins.actions").distinct_setup("ruby", {
     end,
   },
 })
+
+----------------------------------------------------------------------- COPILOT
+-- NOTE: enable copilot for ruby
+
+require("plugins.copilot").enable()

--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -74,3 +74,8 @@ require("plugins.actions").distinct_setup("rust", {
     end,
   },
 })
+
+----------------------------------------------------------------------- COPILOT
+-- NOTE: enable copilot for rust
+
+require("plugins.copilot").enable()

--- a/lua/plugins/copilot.lua
+++ b/lua/plugins/copilot.lua
@@ -61,7 +61,12 @@ end
 ---If the copilot is not already running, run it.
 ---NOTE: by default copilot is disabled for all filetypes
 ---so it will not work for filetype until this is called.
+---NOTE: this will be a noop if the :Copilot command is not available.
+---Meaning, disabling the plugin will also disable this function.
 function M.enable()
+  if vim.fn.exists ":Copilot" == 0 then
+    return
+  end
   if vim.g.copilot_filetypes == nil then
     vim.g.copilot_filetypes = { [vim.o.filetype] = true }
   else

--- a/lua/plugins/copilot.lua
+++ b/lua/plugins/copilot.lua
@@ -1,0 +1,47 @@
+--=============================================================================
+-------------------------------------------------------------------------------
+--                                                               GITHUB COPILOT
+--=============================================================================
+-- https://github.com/github/copilot.vim
+--_____________________________________________________________________________
+
+local M = {}
+
+---The init function for the github copilot.
+---This disables the default tab mapping for the plugin.
+---It will rather map:
+---  <C-Space> to select the next suggestion.
+---  <C-k> to show the next suggestion.
+---  <C-j> to show the previous suggestion.
+function M.init()
+  vim.g.copilot_no_tab_map = true
+  vim.g.copilot_assume_mapped = true
+  M.remappings()
+end
+
+---This maps:
+---  <C-Space> to select the next suggestion.
+---  <C-k> to show the next suggestion.
+---  <C-j> to show the previous suggestion.
+function M.remappings()
+  vim.api.nvim_set_keymap(
+    "i",
+    "<C-Space>",
+    'copilot#Accept("<CR>")',
+    { silent = true, expr = true }
+  )
+  vim.api.nvim_set_keymap(
+    "i",
+    "<C-k>",
+    "copilot#Next()",
+    { silent = true, expr = true }
+  )
+  vim.api.nvim_set_keymap(
+    "i",
+    "<C-j>",
+    "copilot#Previous()",
+    { silent = true, expr = true }
+  )
+end
+
+return M

--- a/lua/plugins/copilot.lua
+++ b/lua/plugins/copilot.lua
@@ -9,6 +9,9 @@ local M = {}
 
 ---The init function for the github copilot.
 ---This disables the default tab mapping for the plugin.
+---Copilot is disabled for all filetypes by default.
+---Call `require('plugins.copilot').enable()`
+---to enable it for the current filetype.
 ---It will rather map:
 ---  <C-Space> to select the next suggestion.
 ---  <C-k> to show the next suggestion.
@@ -16,6 +19,16 @@ local M = {}
 function M.init()
   vim.g.copilot_no_tab_map = true
   vim.g.copilot_assume_mapped = true
+  -- NOTE: disable the copilot for all filetypes by default.
+  local tbl = {
+    ["*"] = false,
+  }
+  if vim.g.copilot_filetypes == nil then
+    vim.g.copilot_filetypes = tbl
+  else
+    vim.g.copilot_filetypes =
+      vim.tbl_extend("force", vim.g.copilot_filetypes, tbl)
+  end
   M.remappings()
 end
 
@@ -42,6 +55,24 @@ function M.remappings()
     "copilot#Previous()",
     { silent = true, expr = true }
   )
+end
+
+---Enable copilot for the current filetype.
+---If the copilot is not already running, run it.
+---NOTE: by default copilot is disabled for all filetypes
+---so it will not work for filetype until this is called.
+function M.enable()
+  if vim.g.copilot_filetypes == nil then
+    vim.g.copilot_filetypes = { [vim.o.filetype] = true }
+  else
+    vim.g.copilot_filetypes =
+      vim.tbl_extend("force", vim.g.copilot_filetypes, {
+        [vim.o.filetype] = true,
+      })
+  end
+  if vim.g.loaded_copilot ~= 1 then
+    vim.cmd "Copilot enable"
+  end
 end
 
 return M

--- a/lua/plugins/copilot.lua
+++ b/lua/plugins/copilot.lua
@@ -7,6 +7,9 @@
 
 local M = {}
 
+---@type table: A table of disabled filetypes
+M.disabled_filetypes = {}
+
 ---The init function for the github copilot.
 ---This disables the default tab mapping for the plugin.
 ---Copilot is disabled for all filetypes by default.
@@ -57,26 +60,70 @@ function M.remappings()
   )
 end
 
----Enable copilot for the current filetype.
+---Enable copilot for the provided filetype, or the
+---current filetype if none is provided.
 ---If the copilot is not already running, run it.
 ---NOTE: by default copilot is disabled for all filetypes
 ---so it will not work for filetype until this is called.
 ---NOTE: this will be a noop if the :Copilot command is not available.
 ---Meaning, disabling the plugin will also disable this function.
-function M.enable()
+---NOTE: This will not work if copilot was disabled for the filetype
+---with `require('plugins.copilot').disable()`.
+---@param filetype string?: the filetype to enable copilot for.
+---If this is not provided, it is enabled for current filetype.
+function M.enable(filetype)
   if vim.fn.exists ":Copilot" == 0 then
     return
   end
+  if filetype == nil then
+    filetype = vim.bo.filetype
+  end
+  -- NOTE: if the copilot is disabled for the current filetype,
+  -- return early.
+  if M.disabled_filetypes[filetype] == true then
+    return
+  end
+  -- NOTE: make sure the copilot is enabled for the current filetype.
   if vim.g.copilot_filetypes == nil then
-    vim.g.copilot_filetypes = { [vim.o.filetype] = true }
+    vim.g.copilot_filetypes = { [filetype] = true }
   else
     vim.g.copilot_filetypes =
       vim.tbl_extend("force", vim.g.copilot_filetypes, {
-        [vim.o.filetype] = true,
+        [filetype] = true,
       })
   end
   if vim.g.loaded_copilot ~= 1 then
     vim.cmd "Copilot enable"
+  end
+end
+
+---Disable copilot for the provided filetype, or the
+---current filetype if none is provided.
+---This will disable the function `require('plugins.copilot').enable()`
+---for the provided filetype.
+---NOTE: this will be a noop if the :Copilot command is not available.
+---@param filetype string?: the filetype to disable copilot for.
+function M.disable(filetype)
+  if vim.fn.exists ":Copilot" == 0 then
+    return
+  end
+  if filetype == nil then
+    filetype = vim.bo.filetype
+  end
+
+  --NOTE: add it to disabled filetypes so that
+  --it cannot be enabled with the enable function.
+  M.disabled_filetypes[filetype] = true
+
+  --NOTE: add it do the copilot filetypes so that
+  --the copilot will not be enabled for the filetype.
+  if vim.g.copilot_filetypes == nil then
+    vim.g.copilot_filetypes = { [filetype] = false }
+  else
+    vim.g.copilot_filetypes =
+      vim.tbl_extend("force", vim.g.copilot_filetypes, {
+        [filetype] = false,
+      })
   end
 end
 

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -50,10 +50,16 @@ function plugins.setup()
       end,
       run = { ":TSUpdate" },
     }
+    ------------------------------------------------------------ GITHUB COPILOT
+    -- GitHub Copilot uses OpenAI Codex to suggest code and
+    -- entire functions in real-time right from your editor.
     use {
       "github/copilot.vim",
-      cmd = { "Copilot" },
       opt = true,
+      cmd = { "Copilot" },
+      setup = function()
+        require("plugins.copilot").init()
+      end,
     }
     -------------------------------------------------------------- ACTIONS.NVIM
     -- manage and synchronously run actions

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -50,6 +50,11 @@ function plugins.setup()
       end,
       run = { ":TSUpdate" },
     }
+    use {
+      "github/copilot.vim",
+      cmd = { "Copilot" },
+      opt = true,
+    }
     -------------------------------------------------------------- ACTIONS.NVIM
     -- manage and synchronously run actions
     use {

--- a/plugin/remappings.lua
+++ b/plugin/remappings.lua
@@ -115,32 +115,6 @@ vim.api.nvim_set_keymap("i", ".", ".<c-g>u", { noremap = true })
 vim.api.nvim_set_keymap("i", "!", "!<c-g>u", { noremap = true })
 vim.api.nvim_set_keymap("i", "?", "?<c-g>u", { noremap = true })
 
-------------------------------------------------------------------- MOVING TEXT
--- switch lines in normal mode with leader-j or leader-k
--- switch lines in insert mode with ctrl-j or ctrl-k
--- switch selected text in visual mode with J or K
-
-vim.api.nvim_set_keymap("v", "K", "<cmd>m '>+1<CR>gv=gv", { noremap = true })
-vim.api.nvim_set_keymap("v", "J", "<cmd>m '<-2<CR>gv=gv", { noremap = true })
-vim.api.nvim_set_keymap("i", "<C-k>", "<esc><cmd>m .-2<CR>==", {
-  noremap = true,
-})
-vim.api.nvim_set_keymap("i", "<C-J>", "<esc><cmd>m .+1<CR>==", {
-  noremap = true,
-})
-vim.api.nvim_set_keymap(
-  "n",
-  "<leader>k",
-  "<cmd>m .-2<CR>==",
-  { noremap = true }
-)
-vim.api.nvim_set_keymap(
-  "n",
-  "<leader>j",
-  "<cmd>m .+1<CR>==",
-  { noremap = true }
-)
-
 ----------------------------------------------------------------------- WRITING
 
 vim.api.nvim_create_user_command(


### PR DESCRIPTION
- Add [Github Copilot](https://github.com/github/copilot.vim) plugin.
  - It is lazily loaded.
  - By default enabled for `lua, python, rust, go, ruby, ocaml`.
  - To enable it for a filetype, call `require('plugins.copilot').enable()` in the filetype's `ftplugin/` file (or delete this line from a `ftplugin/` file to disable it for that filetype).
  - It may also be enabled from other files, example from local configs, but then filetype should be passed into the function (`require('plugins.copilot').enable('filetype')`).
  - It may also be disabled with `require('plugins.copilot').disable('filetype')`. This is useful when we want it enabled for a filetype by default, but disabled only for a specific project (disable it in a local config).
  
- Before using it, `:Copilot setup` should be called.
  - This replies with a set of instructions that should be followed to enable the copilot.
  - This should link the neovim to your github user, you may then logout with `:Copilot signout`.
  - See the current status of the copilot with `:Copilot status`.

- Changed the plugin's default mappings:
  - `<Ctrl + Space>` selects the shown suggestion.
  - `<Ctrl + K>` Shows the next available suggestion.
  - `<Ctrl + J>` Shows the previous suggestion.
    
- See `:help copilot` (**NOTE** it is lazily loaded so this will not be found until `:Copilot <something>` is called).

- **_NOTE_** To disable the plugin completely, comment the following section in [plugins/init.lua](./lua/plugins/init.lua), then reload neovim and run `:PackerSync`.
```lua
    ------------------------------------------------------------ GITHUB COPILOT
    -- GitHub Copilot uses OpenAI Codex to suggest code and
    -- entire functions in real-time right from your editor.
    use {
      "github/copilot.vim",
      opt = true,
      cmd = { "Copilot" },
      setup = function()
        require("plugins.copilot").init()
      end,
    }

```