### PR TITLE
Actions with telescope

### DIFF
--- a/lua/plugins/actions.lua
+++ b/lua/plugins/actions.lua
@@ -18,9 +18,14 @@ function M.init()
     require("actions").setup(config)
   end
   vim.api.nvim_create_user_command("Actions", function()
-    require("actions.telescope").available_actions(
-      require("telescope.themes").get_ivy()
-    )
+    pcall(require, "telescope")
+    if package.loaded["telescope"] then
+      require("actions.telescope").available_actions(
+        require("telescope.themes").get_ivy()
+      )
+    else
+      require("actions").available_actions()
+    end
   end, {})
   vim.api.nvim_set_keymap(
     "n",

--- a/lua/plugins/actions.lua
+++ b/lua/plugins/actions.lua
@@ -17,11 +17,11 @@ function M.init()
   for _, config in ipairs(setups) do
     require("actions").setup(config)
   end
-  vim.api.nvim_create_user_command(
-    "Actions",
-    require("actions").available_actions,
-    {}
-  )
+  vim.api.nvim_create_user_command("Actions", function()
+    require("actions.telescope").available_actions(
+      require("telescope.themes").get_ivy()
+    )
+  end, {})
   vim.api.nvim_set_keymap(
     "n",
     "<leader>e",

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -155,6 +155,7 @@ function plugins.setup()
       as = "telescope",
       cond = 'require("plugins").enabled("telescope")',
       opt = true,
+      module_pattern = "telescope.*",
       keys = {
         "<leader>n",
         "<C-x>",


### PR DESCRIPTION
Available actions are now displayed in a Telescope prompt.
  - If telescope.nvim is not available, the normal window is used.