### PR TITLE
Fix treesitter module's invalid name

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -43,7 +43,7 @@ function plugins.setup()
     -- such as highlighting based on it
     Plugin:new(use, {
       "nvim-treesitter/nvim-treesitter",
-      as = "treesitter",
+      as = "nvim-treesitter",
       run = { ":TSUpdate" },
     })
     ------------------------------------------------------------ GITHUB COPILOT
@@ -167,7 +167,7 @@ function plugins.setup()
             -- autocomplete matching parentheses etc.
             {
               "windwp/nvim-autopairs",
-              module_pattern = { "cmp", "cmp.*", "nvim-autopairs.*" },
+              module_pattern = { "cmp.*", "nvim-autopairs.*" },
             },
           },
         },

--- a/lua/plugins/nvim-treesitter.lua
+++ b/lua/plugins/nvim-treesitter.lua
@@ -5,7 +5,7 @@
 -- https://github.com/nvim-treesitter/nvim-treesitter
 --_____________________________________________________________________________
 
-local treesitter = require("util.packer_wrapper").get "treesitter"
+local treesitter = require("util.packer_wrapper").get "nvim-treesitter"
 
 ---Default setup for the treesitter
 treesitter:config(function()


### PR DESCRIPTION
Fix but for autopairs plugin as it could not find the nvim-treesitter module.
  - Renamed the treesitter plugin to `nvim-treesitter` to avoid this.